### PR TITLE
Add 3.10 to supported shell versions

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -8,11 +8,12 @@ function init() {
 
 function enable() {
     // monkey patch
-    Main.wm._workspaceSwitcherPopup = function(actor) {
-        return false;
-    }
+    Main.wm._workspaceSwitcherPopup = {
+        actor: {hide: function() { return false; }},
+        display: function (direction, index) { return false; },
+        destroy: function () { return false; },
+        };
 }
-
 function disable() {
     Main.wm._workspaceSwitcherPopup = oldWorkspaceSwitcherPopup;
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-  "shell-version": ["3.0", "3.0.1", "3.0.2", "3.2", "3.6"],
+  "shell-version": ["3.0", "3.0.1", "3.0.2", "3.2", "3.6", "3.8", "3.10"],
   "uuid": "disable-workspace-switcher-popup@github.com",
   "name": "Disable Workspace Switcher Popup",
   "description": "Disables arrow overlay when switching between workspaces"


### PR DESCRIPTION
Gnome 3.10 added workspace switcher popup to 'switch-to-workspace-n'
keyboard shortcuts.
