### PR TITLE
Override WorkspaceSwitcherPopup._show() instead of the whole object

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1,21 +1,17 @@
-const Main = imports.ui.main;
+const WorkspaceSwitcherPopup = imports.ui.workspaceSwitcherPopup;
 
-let oldWorkspaceSwitcherPopup;
+let oldShow;
 
 function init() {
-    oldWorkspaceSwitcherPopup = Main.wm._workspaceSwitcherPopup;
+    oldShow = WorkspaceSwitcherPopup.WorkspaceSwitcherPopup.prototype._show;
 }
 
 function enable() {
-    // monkey patch
-    Main.wm._workspaceSwitcherPopup = {
-        actor: {hide: function() { return false; }},
-        display: function (direction, index) { return false; },
-        destroy: function () { return false; },
-        };
+    WorkspaceSwitcherPopup.WorkspaceSwitcherPopup.prototype._show = function() { return false };
 }
+
 function disable() {
-    Main.wm._workspaceSwitcherPopup = oldWorkspaceSwitcherPopup;
+    WorkspaceSwitcherPopup.WorkspaceSwitcherPopup.prototype._show = oldShow;
 }
 
 // Backwards compatability with 3.0.2


### PR DESCRIPTION
This makes the code a bit simpler, but just as effective. This was
tested on 3.12, but review of the gnome-shell code indicates it should
also work on 3.0 and probably everything in between as well.

By overriding _show (as opposed to display), this extension now plays
well with the Frippery Bottom Panel extension, which provides its own
(horizontal) workspace switcher popup. Since it still uses the original
_show function, with this change the Frippery version of the switcher is
also hidden as well when both extensions are combined.

A small downside of overriding _show instead of display is that the
switcher popup is still created and, after a timeout, destroyed in the
background, it's just not being shown. This should not cause any
problems, though.
