### PR TITLE
Support GNOME 3.13 and 3.14 too.

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,5 @@
 {
-    "shell-version": ["3.0", "3.0.1", "3.0.2", "3.2", "3.6", "3.8", "3.10", "3.12"],
+    "shell-version": ["3.0", "3.0.1", "3.0.2", "3.2", "3.6", "3.8", "3.10", "3.12", "3.13", "3.14"],
     "uuid": "disable-workspace-switcher-popup@github.com",
     "name": "Disable Workspace Switcher Popup",
     "description": "Disables arrow overlay when switching between workspaces",


### PR DESCRIPTION
I'm using this change in my GNOME 3.14 shell on Debian GNU/Linux right now, and it seems to work fine.  Apparently no code changes are necessary to support 3.14; we just needed `metadata.json` to declare support explicitly.
