### PR TITLE
Add 3.16 to supported versions

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,17 @@
 {
-    "shell-version": ["3.0", "3.0.1", "3.0.2", "3.2", "3.6", "3.8", "3.10", "3.12", "3.13", "3.14"],
+    "shell-version": [
+        "3.0",
+        "3.0.1",
+        "3.0.2",
+        "3.2",
+        "3.4",
+        "3.6",
+        "3.8",
+        "3.10",
+        "3.12",
+        "3.14",
+        "3.16"
+    ],
     "uuid": "disable-workspace-switcher-popup@github.com",
     "name": "Disable Workspace Switcher Popup",
     "description": "Disables arrow overlay when switching between workspaces",


### PR DESCRIPTION
Also added 3.4 for completeness which presumably works as 3.2 and 3.6
work and dropped 3.13 as it was a development release.