### PR TITLE
Add 3.20.2 to supported versions

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -12,7 +12,8 @@
         "3.14",
         "3.16",
         "3.18",
-        "3.20"
+        "3.20",
+        "3.20.2"
     ],
     "uuid": "disable-workspace-switcher-popup@github.com",
     "name": "Disable Workspace Switcher Popup",


### PR DESCRIPTION
I cannot install this extension from the [extensions.gnome.org](https://extensions.gnome.org/extension/959/disable-workspace-switcher-popup/) because I'm using `gnome-shell` version `3.20.2`.