### PR TITLE
add support for gnome-shell 3.22.2

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -16,7 +16,8 @@
         "3.20.2",
         "3.20.3",
         "3.21.91",
-        "3.22"
+        "3.22",
+        "3.22.2"
     ],
     "uuid": "disable-workspace-switcher-popup@github.com",
     "name": "Disable Workspace Switcher Popup",


### PR DESCRIPTION
This has been tested successfully on Fedora 25 running 3.22.2.