### PR TITLE
Gnome 40 support

### DIFF
--- a/disable-workspace-switcher-popup@github.com/metadata.json
+++ b/disable-workspace-switcher-popup@github.com/metadata.json
@@ -26,7 +26,8 @@
         "3.30.2",
         "3.32",
         "3.32.2",
-        "3.34.1"
+        "3.34.1",
+        "40"
     ],
     "uuid": "disable-workspace-switcher-popup@github.com",
     "name": "Disable Workspace Switcher Popup",


### PR DESCRIPTION
This PR adds Gnome 40 support by adding `40` to the `shell-version` list.

I also confirmed that this is working in Gnome 40 (on Arch).